### PR TITLE
Add support for configuration files

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	uri := flag.String("uri", "/novnc/", "Base URI for handling WS requests")
 	logLevel := flag.Int("log-level", int(logrus.InfoLevel), "Logging level")
 
+	flag.String(flag.DefaultConfigFlagname, "", "path to config file")
 	flag.Parse()
 
 	logrus.SetLevel(logrus.Level(*logLevel))


### PR DESCRIPTION
Allow users to specify a configuration file via the -config option. This avoids having to expose the JWE secret on the command line.